### PR TITLE
added check for empty kid list to reset resume token

### DIFF
--- a/app/src/main/java/it/ministerodellasalute/verificaC19/data/VerifierRepositoryImpl.kt
+++ b/app/src/main/java/it/ministerodellasalute/verificaC19/data/VerifierRepositoryImpl.kt
@@ -59,6 +59,10 @@ class VerifierRepositoryImpl @Inject constructor(
                 validCertList.clear()
                 validCertList.addAll(body)
 
+                if (body.isEmpty()) {
+                    preferences.resumeToken = -1L
+                }
+
                 val resumeToken = preferences.resumeToken
                 fetchCertificate(resumeToken)
                 db.keyDao().deleteAllExcept(validCertList.toTypedArray())


### PR DESCRIPTION
if kid list is empty, resume token is reset to default value (-1 Long) to allow downloading all certificates again next time